### PR TITLE
Fixed scanning to skip directories with no permissions instead of failing.

### DIFF
--- a/lib/helpers/scan.js
+++ b/lib/helpers/scan.js
@@ -90,11 +90,11 @@ function insertPathToIndex(alias, realpath){
 }
 
 function shouldScanFurther(root,file){
-    if (file.substr(0,1) === "." ||
-        !fs.statSync(root+"/"+file).isDirectory()) {
+    // try catch - because statSync can't handle errors based on permissions.
+    try {
+        return file.substr(0,1) !== "." && fs.statSync(root+"/"+file).isDirectory();
+    } catch(e) {
         return false;
-    }else{
-        return true;
     }
 }
 


### PR DESCRIPTION
When 'scan' finds a directory to which it has not permissions, to fails instead of skipping it.

Reproduce original bug with:

```
mkdir 1
touch 1/file.txt
chmod 600 1
npm i rekuire

node
var rek = require('rekuire')
```

This could be more cleanly solved by using fs.stat instead of fs.statSync, but that would rekuire some work... :]
