### PR TITLE
takes `baseDir` value from environment variable

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ delete require.cache[require.resolve(__filename)];
 
 var path = require('path');
 var scanner = require('./helpers/scanner');
-var baseDir = path.normalize( __dirname + "/../../../");
+var baseDir = process.env.REKUIRE_BASE_DIR || path.normalize( __dirname + "/../../../");
 var pkg = require(path.join(baseDir, "package.json"));
 if (pkg.rekuire){
     if (pkg.rekuire.ignore){


### PR DESCRIPTION
I had to do this update because of problems when run my app on AWS ElasticBeanstalk. They have node_modules folder as a link to other location that's why calculation of `baseDir` pointed to wrong directory. Obvious fix for such specific situation is to take `baseDir` value from environment variable.
